### PR TITLE
Return jqXHR object from $.ajax, so getFeed is compatible with jQuery 1.5

### DIFF
--- a/src/jfeed.js
+++ b/src/jfeed.js
@@ -18,7 +18,7 @@ jQuery.getFeed = function(options) {
 
     if (options.url) {
 
-        $.ajax({
+        return $.ajax({
             type: 'GET',
             url: options.url,
             data: options.data,


### PR DESCRIPTION
Return jqXHR object from $.ajax, so getFeed is compatible with jQuery 1.5 Deferred API.
