### PR TITLE
Fix jFeed in latest jQuery

### DIFF
--- a/build/dist/jquery.jfeed.js
+++ b/build/dist/jquery.jfeed.js
@@ -31,6 +31,10 @@ jQuery.getFeed = function(options) {
             window.console&&console.log('getFeed failed to load feed', xhr, msg, e);
           }
         }
+        
+        if (!jQuery.hasOwnProperty('browser')) {
+            jQuery.browser = {};
+        }
 
         return $.ajax({
             type: 'GET',


### PR DESCRIPTION
jQuery.browser doesn't exist in newer versions of jQuery. Add it so line 44 doesn't throw an exception and prevent further script execution.

`jquery.jfeed.js:40 Uncaught TypeError: Cannot read property 'msie' of undefined`
